### PR TITLE
Fix application status and typos

### DIFF
--- a/src/app/get_involved/technical-fellowship/page.tsx
+++ b/src/app/get_involved/technical-fellowship/page.tsx
@@ -126,7 +126,7 @@ export default function TechnicalFellowshipPage() {
             here 
           </a> for the curriculum (subject to change).
         </p>
-        <p><strong>Applications for the Spring 2026 Technical Fellowships are now open! <a href="https://docs.google.com/forms/d/e/1FAIpQLSc51ikVAmLDjDx216mCgioHgImXIgPpIY79b0DK7D3PSqdJtg/viewform">Apply here.</a></strong>. </p>
+        <p><strong>Applications for the Spring 2026 Technical Fellowships are now open! <a href="https://docs.google.com/forms/d/e/1FAIpQLSc51ikVAmLDjDx216mCgioHgImXIgPpIY79b0DK7D3PSqdJtg/viewform">Apply here.</a></strong></p>
         <p>For those interested in the policy and governance side of AI, we recommend applying to our introductory <a 
             href="/get_involved/policy-fellowship" 
             className="text-[#4A8A99] hover:underline"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -70,7 +70,7 @@ export default async function Home() {
             <p className="text-lg leading-relaxed text-gray-600">
               We also run a semester-long introductory reading group on AI safety, including both a <a href="/get_involved/technical-fellowship" className="text-[#4A8A99] hover:underline">technical machine learning track</a>, and a <a href="/get_involved/policy-fellowship" className="text-[#4A8A99] hover:underline">policy track</a>.
             </p>
-            <p><strong>Applications for both our fellowships are now closed! Please look out for us next semester.</strong></p>
+            <p><strong>Applications for both our fellowships are now open! Apply by January 28th.</strong></p>
           </div>
 
           {/* Logos Section */}

--- a/src/app/resources/policy-resources/page.tsx
+++ b/src/app/resources/policy-resources/page.tsx
@@ -48,12 +48,12 @@ const resources = [
   },
   {
     title: "Presidential Innovation Fellowship",
-    description: "A fellowship the brings technical individuals to government.",
+    description: "A fellowship that brings technical individuals to government.",
     link: "https://presidentialinnovationfellows.gov/"
   },
   {
     title: "AAAS Science & Technology Policy Fellowships (STPF)",
-    description: "(Copied) The fellowship program offers hands-on opportunities to apply your scientific knowledge and technical skills to important societal challenges.",
+    description: "The fellowship program offers hands-on opportunities to apply your scientific knowledge and technical skills to important societal challenges.",
     link: "http://www.stpf-aaas.org/"
   }
 ];


### PR DESCRIPTION
- Update homepage to show applications are open (deadline Jan 28th)
- Fix typo: "the brings" → "that brings" in policy resources
- Remove "(Copied)" marker from AAAS fellowship description
- Remove double period in technical fellowship application link