### PR TITLE
Collider page: link "Collider, NYC" in the hero tagline

### DIFF
--- a/src/app/get_involved/collider/page.tsx
+++ b/src/app/get_involved/collider/page.tsx
@@ -120,7 +120,16 @@ export default function ColliderPage() {
             CAIAC @ Collider
           </h1>
           <p className="mt-5 max-w-2xl text-lg sm:text-xl text-white/90 font-light drop-shadow">
-            A summer paper club reading frontier research on AI safety, interpretability, and alignment science at Collider, NYC.
+            A summer paper club reading frontier research on AI safety, interpretability, and alignment science at{" "}
+            <a
+              href="https://collider.nyc"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-inherit hover:no-underline"
+            >
+              Collider, NYC
+            </a>
+            .
           </p>
 
           <a


### PR DESCRIPTION
Makes "Collider, NYC" in the CAIAC @ Collider hero tagline a link to collider.nyc.

Styled to blend with the tagline — same color, no underline (at rest or hover) — so it's a quiet inline link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)